### PR TITLE
Pass the asciidocConfig to classifyContent

### DIFF
--- a/lib/generate-site.js
+++ b/lib/generate-site.js
@@ -15,11 +15,11 @@ const { resolveConfig: resolveAsciiDocConfig } = require('@antora/asciidoc-loade
 
 async function generateSite (args, env) {
   const playbook = buildPlaybook(args, env)
+  const asciidocConfig = resolveAsciiDocConfig(playbook)
   const [contentCatalog, uiCatalog] = await Promise.all([
-    aggregateContent(playbook).then((contentAggregate) => classifyContent(playbook, contentAggregate)),
+    aggregateContent(playbook).then((contentAggregate) => classifyContent(playbook, contentAggregate, asciidocConfig)),
     loadUi(playbook),
   ])
-  const asciidocConfig = resolveAsciiDocConfig(playbook)
   const pages = convertDocuments(contentCatalog, asciidocConfig)
   const navigationCatalog = buildNavigation(contentCatalog, asciidocConfig)
   const composePage = createPageComposer(playbook, contentCatalog, uiCatalog, env)


### PR DESCRIPTION
Backport: https://gitlab.com/antora/antora/-/commit/290d6f3cf45ed6bfcb4a25b1ec0d4caafe4af2c2 (introduced in Antora v2.3.0)


//cc @mojavelinux @brunchboy