### PR TITLE
Reformat the upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Upgrading Antora alone isn't sufficient.
 To upgrade this site generator and Antora, open a terminal and type the following commands:
 
     $ npm uninstall -g antora-site-generator-lunr @antora/cli @antora/site-generator-default
-      npm i -g antora-site-generator-lunr @antora/cli @antora/site-generator-default
+    
+    $ npm i -g antora-site-generator-lunr @antora/cli @antora/site-generator-default
 
 These commands ensure you have the latest version of both the site generator and Antora regardless of whether you're using this site generator.


### PR DESCRIPTION
Hi

thanks for your work !

A separator is missing between the uninstall and the install command. 
Here is a proposition to show that there are indeed 2 different commands.